### PR TITLE
fixed modal

### DIFF
--- a/src/components/ProviderInfoMobile.jsx
+++ b/src/components/ProviderInfoMobile.jsx
@@ -139,7 +139,7 @@ const ProviderInfo = (props) => (
           <br />
         </h5>
       ) : <div />}
-      {props.item.epic[0] ? (
+      {(!(props.item.epic === undefined) && props.item.epic[0]) ? (
         <h5>
   EPIC Designation
           <FaCheck />


### PR DESCRIPTION
Problem: Fixed modal crashes.

Reason: In ProviderInfoMobile, there was a section that checks if epic was marked true but some providers dont have epic as an element of item.

Solution: checked if epic is defined before checking if it is marked to true